### PR TITLE
Added fix for when ids contain "/" characters.

### DIFF
--- a/SvgConverter/CmdLineHandler.cs
+++ b/SvgConverter/CmdLineHandler.cs
@@ -21,7 +21,7 @@ namespace SvgConverter
             {
                 return clp.ParseArgs(args, true);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 //nothing to do, the errors are hopefully already reported via CommandLineParser
                 Console.WriteLine("Error while handling Commandline.");

--- a/SvgConverter/CmdLineTarget.cs
+++ b/SvgConverter/CmdLineTarget.cs
@@ -27,7 +27,11 @@ namespace SvgConverter
             [ArgumentParam(DefaultValue = null, ExplicitNeeded = false, LongDesc = "Namespace to use with UseResKey")]
             string compResKeyNS = null,
             [ArgumentParam(DefaultValue = null, ExplicitNeeded = false, LongDesc = "name of Namespace to use with UseResKey" )]
-            string compResKeyNSName = null
+            string compResKeyNSName = null,
+            [ArgumentParam(DefaultValue = null, ExplicitNeeded = false, LongDesc = "Extract child elements into separate resources, default true" )]
+            bool extractChildElements = true,
+            [ArgumentParam(DefaultValue = null, ExplicitNeeded = false, LongDesc = "If true will not use hardcoded Brush values but rather a binding to SvgConvertedImageSourceBehavior that can be used to dynamically set the image color. Set this behavior on Images. Use together with extractChildElements:false.", ExplicitWantedArguments = "extractChildElements")]
+            bool useSvgConvertedImageSourceBehavior = false
             )
         {
             Console.WriteLine("Building resource dictionary...");
@@ -43,6 +47,8 @@ namespace SvgConverter
                 UseComponentResKeys = useComponentResKeys,
                 NameSpace = compResKeyNS,
                 NameSpaceName = compResKeyNSName,
+                ExtractChildElements = extractChildElements,
+                UseSvgConvertedImageSourceBehavior = useSvgConvertedImageSourceBehavior
             };
 
             File.WriteAllText(outFileName, ConverterLogic.SvgDirToXaml(inputdir, resKeyInfo, null));

--- a/SvgConverter/ConverterLogic.cs
+++ b/SvgConverter/ConverterLogic.cs
@@ -104,12 +104,19 @@ namespace SvgConverter
             foreach (var drawingGroupElement in drawingGroupElements)
             {
                 BeautifyDrawingElement(drawingGroupElement, null);
-                ExtractGeometries(drawingGroupElement, resKeyInfo);
+
+                if (resKeyInfo.ExtractChildElements)
+                {
+                    ExtractGeometries(drawingGroupElement, resKeyInfo);
+                }
             }
 
             AddNameSpaceDef(doc.Root, resKeyInfo);
-            //ReplaceBrushesInDrawingGroups(doc.Root, resKeyInfo);
-            AddDrawingImagesToDrawingGroups(doc.Root);
+            if (resKeyInfo.UseSvgConvertedImageSourceBehavior)
+            {
+                ReplaceBrushesInDrawingGroups(doc.Root, resKeyInfo);
+            }
+            AddDrawingImagesToDrawingGroups(doc.Root, resKeyInfo);
             return doc.ToString();
         }
 
@@ -217,7 +224,7 @@ namespace SvgConverter
                     var color = brushAttribute.Value;
                     var index = brushAttributes.IndexOf(brushAttribute);
                     brushAttribute.Value =
-                        $"{{Binding Path=(brushes:Props.ContentBrushes)[{index}], RelativeSource={{RelativeSource AncestorType=Visual}}, FallbackValue={color}}}";
+                        $"{{Binding Path=(behaviors:SvgConvertedImageSourceBehavior.BrushesAssist)[{index}], RelativeSource={{RelativeSource Mode=FindAncestor, AncestorType=DrawingImage}}, FallbackValue={color}, TargetNullValue={color}}}";
                 }
             }
 
@@ -231,7 +238,7 @@ namespace SvgConverter
                 .Where(a => a.Value.StartsWith("#")); //is Color like #FF000000
         }
 
-        private static void AddDrawingImagesToDrawingGroups(XElement rootElement)
+        private static void AddDrawingImagesToDrawingGroups(XElement rootElement, ResKeyInfo resKeyInfo)
         {
             var drawingGroups = rootElement.Elements(NsDef + "DrawingGroup").ToList();
             foreach (var node in drawingGroups)
@@ -240,11 +247,22 @@ namespace SvgConverter
                 var nameDg = node.Attribute(Nsx + "Key").Value;
                 var nameImg = nameDg.Replace("DrawingGroup", "DrawingImage");
                 //<DrawingImage x:Key="xxx" Drawing="{StaticResource cloud_5_icon_DrawingGroup}"/>
-                var drawingImage = new XElement(NsDef + "DrawingImage",
-                    new XAttribute(Nsx + "Key", nameImg),
-                    new XAttribute("Drawing", string.Format("{{StaticResource {0}}}", nameDg))
-                    );
+                var drawingImage = new XElement(NsDef + "DrawingImage", new XAttribute(Nsx + "Key", nameImg));
+
                 node.AddAfterSelf(drawingImage);
+                if (resKeyInfo.ExtractChildElements)
+                {
+                    drawingImage.Add(new XAttribute("Drawing", string.Format("{{StaticResource {0}}}", nameDg)));
+                }
+                else
+                {
+                    var drawingImageDrawing = new XElement(NsDef + "DrawingImage.Drawing");
+                    drawingImage.Add(drawingImageDrawing);
+                    
+                    node.Attribute(XName.Get("Key", node.GetNamespaceOfPrefix("x").NamespaceName)).Remove();
+                    node.Remove();
+                    drawingImageDrawing.Add(node);
+                }
             }
         }
 

--- a/SvgConverter/ConverterLogic.cs
+++ b/SvgConverter/ConverterLogic.cs
@@ -349,7 +349,7 @@ namespace SvgConverter
 
             //workaround: error when Id starts with a number
             var doc = XDocument.Load(Path.GetFullPath(filepath));
-            ReplaceIdsWithNumbers(doc.Root); //id="3d-view-icon" -> id="_3d-view-icon"
+            FixIds(doc.Root); //id="3d-view-icon" -> id="_3d-view-icon"
             using (var ms = new MemoryStream())
             {
                 doc.Save(ms);
@@ -359,17 +359,22 @@ namespace SvgConverter
             }
         }
 
-        private static void ReplaceIdsWithNumbers(XElement root)
+        private static void FixIds(XElement root)
         {
             var idAttributesStartingWithDigit = root.DescendantsAndSelf()
                 .SelectMany(d=>d.Attributes())
-                .Where(a=>string.Equals(a.Name.LocalName, "Id", StringComparison.InvariantCultureIgnoreCase))
-                .Where(a=>char.IsDigit(a.Value.FirstOrDefault()));
+                .Where(a=>string.Equals(a.Name.LocalName, "Id", StringComparison.InvariantCultureIgnoreCase));
             foreach (var attr in idAttributesStartingWithDigit)
             {
-                attr.Value = "_" + attr.Value;
+                if (char.IsDigit(attr.Value.FirstOrDefault()))
+                {
+                    attr.Value = "_" + attr.Value;
+                }
+
+                attr.Value = attr.Value.Replace("/", "_");
             }
         }
+
 
         internal static DrawingImage DrawingToImage(Drawing drawing)
         {

--- a/SvgConverter/ResKeyInfo.cs
+++ b/SvgConverter/ResKeyInfo.cs
@@ -8,5 +8,7 @@
         public bool UseComponentResKeys { get; set; }
         public string NameSpace { get; set; }
         public string NameSpaceName { get; set; }
+        public bool ExtractChildElements { get; set; }
+        public bool UseSvgConvertedImageSourceBehavior { get; set; }
     }
 }

--- a/SvgConverter/SvgConvertedImageSourceBehavior.cs
+++ b/SvgConverter/SvgConvertedImageSourceBehavior.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Interactivity;
+using System.Windows.Markup;
+using System.Windows.Media;
+
+namespace SvgConverter
+{
+    /// <summary>
+    /// If the converter is run with /extractChildElements:false /useSvgConvertedImageSourceBehavior:true then this behavior can be used like so:
+    ///  <Image Width="64" Height="64" >
+    ///      <i:Interaction.Behaviors>
+    ///          <local:SvgConvertedImageSourceBehavior Source="{StaticResource invoice_readyDrawingImage}">
+    ///             <SolidColorBrush Color="Firebrick"/>
+    ///             <SolidColorBrush Color="Red"/>
+    ///         </local:SvgConvertedImageSourceBehavior>
+    ///     </i:Interaction.Behaviors>
+    ///  </Image>
+    /// ...thereby enabling dynamic colors for the icons.
+    /// </summary>
+    [ContentProperty("Brushes")]
+    public class SvgConvertedImageSourceBehavior : Behavior<Image>
+    {
+        public SvgConvertedImageSourceBehavior()
+        {
+            this.Brushes = new ArrayList();
+        }
+
+        public static readonly DependencyProperty BrushesAssistProperty = DependencyProperty.RegisterAttached("BrushesAssist", typeof(IList), typeof(SvgConvertedImageSourceBehavior));
+
+        public static IList GetBrushesAssist(DependencyObject element)
+        {
+            return (IList)element.GetValue(BrushesAssistProperty);
+        }
+        public static void SetBrushesAssist(DependencyObject element, IList value)
+        {
+            element.SetValue(BrushesAssistProperty, value);
+        }
+
+        public static readonly DependencyProperty SourceProperty = DependencyProperty.Register("Source", typeof(DrawingImage), typeof(SvgConvertedImageSourceBehavior));
+
+        public DrawingImage Source
+        {
+            get { return (DrawingImage)GetValue(SourceProperty); }
+            set { SetValue(SourceProperty, value); }
+        }
+
+        public static readonly DependencyProperty BrushesProperty = DependencyProperty.Register("Brushes", typeof(IList), typeof(SvgConvertedImageSourceBehavior));
+
+        public IList Brushes
+        {
+            get { return (IList)GetValue(BrushesProperty); }
+            set { SetValue(BrushesProperty, value); }
+        }
+       
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+
+
+            var clonedSource = Source.Clone();
+            this.AssociatedObject.Source = clonedSource;
+
+            if (Brushes != null)
+            {
+                SetBrushesAssist(clonedSource, Brushes);
+            }
+        }
+    }
+}

--- a/SvgConverter/SvgConverter.csproj
+++ b/SvgConverter/SvgConverter.csproj
@@ -68,6 +68,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Windows.Interactivity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -84,6 +85,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ConverterLogic.cs" />
     <Compile Include="ResKeyInfo.cs" />
+    <Compile Include="SvgConvertedImageSourceBehavior.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Also added support for dynamically changing image colors at runtime using a behavior.

 If the converter is run with /extractChildElements:false /useSvgConvertedImageSourceBehavior:true then this behavior can be used like so:
```
<Image Width="64" Height="64" >
    <i:Interaction.Behaviors>
         <local:SvgConvertedImageSourceBehavior Source="{StaticResource invoice_readyDrawingImage}">
             <SolidColorBrush Color="Firebrick"/>
             <SolidColorBrush Color="Red"/>
         </local:SvgConvertedImageSourceBehavior>
   </i:Interaction.Behaviors>
</Image>
```
...thereby enabling dynamic colors for the icons.